### PR TITLE
Update types to support children

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import * as React from 'react';
 export type Size = string | number;
 
 export interface Props {
+  children?: React.ReactNode;
   allowResize?: boolean;
   className?: string;
   primary?: 'first' | 'second';
@@ -51,6 +52,7 @@ declare class SplitPane extends React.Component<Props, State> {
 }
 
 export interface PaneProps {
+  children?: React.ReactNode;
   split?: 'vertical' | 'horizontal';
   initialSize?: Size;
   minSize?: Size;

--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -8,8 +8,8 @@ const Wrapper = styled.div`
   box-sizing: border-box;
   background-clip: padding-box;
   margin: 2px;
-    .hideResizer: {
-      display: none;
+  .hideResizer: {
+    display: none;
   }
   :hover {
     opacity: 0.1;

--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -3,13 +3,16 @@ import styled from 'styled-components';
 
 const Wrapper = styled.div`
   background: #000;
-  opacity: 0.2;
+  opacity: 0;
   z-index: 1;
   box-sizing: border-box;
   background-clip: padding-box;
-
+  margin: 2px;
+    .hideResizer: {
+      display: none;
+  }
   :hover {
-    transition: all 2s ease;
+    opacity: 0.1;
   }
 `;
 


### PR DESCRIPTION
Without this simple change I get a typescript error for both SplitPane and Pane component classes:

Type '{ children: Element[]; split: "horizontal"; allowResize: boolean; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<SplitPane> & Pick<Readonly<Props>, never> & InexactPartial<...> & InexactPartial<...>'.
  Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<SplitPane> & Pick<Readonly<Props>, never> & InexactPartial<...> & InexactPartial<...>'.ts(2322)

It's very long and concerning but all it means is that the component excepts props but that doesn't include passing children and in my use case I need to pass children.

Many thanks for this fork it worked wonders for me!